### PR TITLE
Add env config and improve remote error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,11 @@ tar -xzf archive.tar.gz -C /tmp
 Do you want to execute this command? [y/N] n
 $
 ```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GEMINI_API_KEY` | Yes | — | Your Gemini API key. Used by the local server to call the Gemini API. |
+| `SSHQ_GEMINI_MODEL` | No | `gemini-2.5-flash` | Gemini model name used for command suggestions. |
+| `SSHQ_TUNNEL_PORT` | No | `5000` | Local port for the reverse SSH tunnel and the host server. Change this if port 5000 is already in use. |

--- a/src/sshq/server.py
+++ b/src/sshq/server.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import flask.cli
 from flask import Flask, request, jsonify
 from google import genai
@@ -26,9 +27,11 @@ def ask():
         "Do NOT use markdown formatting (like ```bash). Do NOT provide explanations."
     )
 
+    model = os.environ.get("SSHQ_GEMINI_MODEL", "gemini-2.5-flash")
+
     try:
         response = client.models.generate_content(
-            model='gemini-2.5-flash',
+            model=model,
             contents=data['prompt'],
             config=types.GenerateContentConfig(
                 system_instruction=system_instruction,
@@ -39,9 +42,10 @@ def ask():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-def start_server():
+def start_server(port=None):
     global client
     # Client automatically picks up the GEMINI_API_KEY environment variable
     client = genai.Client()
 
-    app.run(port=5000, host='127.0.0.1', debug=False)
+    port = port or int(os.environ.get("SSHQ_TUNNEL_PORT", "5000"))
+    app.run(port=port, host='127.0.0.1', debug=False)


### PR DESCRIPTION
- Add SSHQ_GEMINI_MODEL (default: gemini-2.5-flash) and SSHQ_TUNNEL_PORT (default: 5000); keep existing behavior when unset
- Document GEMINI_API_KEY, SSHQ_GEMINI_MODEL, and SSHQ_TUNNEL_PORT in README
- In q script, handle HTTPError separately and show server error body so API failures (e.g. invalid model) show the real message instead of "Tunnel is down"