### PR TITLE
Use a random free port for tunnel; drop SSHQ_TUNNEL_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When working on embedded boards (like Yocto or Buildroot builds), you often face
 ## How it Works
 
 1. **The Host Server:** When you run `sshq`, it spins up a lightweight local web server in the background on your laptop. This server securely holds your `GEMINI_API_KEY` and talks to the Gemini API.
-2. **The Reverse Tunnel:** `sshq` wraps your standard `ssh` command and adds a reverse port forward (`-R 5000:localhost:5000`), creating a secure tunnel from the board back to your laptop.
+2. **The Reverse Tunnel:** `sshq` wraps your standard `ssh` command and adds a reverse port forward to a random local port, creating a secure tunnel from the board back to your laptop.
 3. **Transparent Injection:** During login, `sshq` passes a Python one-liner to the board (the `q` client script) and drops it into `~/.local/bin/q`, and immediately hands you an interactive shell.
 
 ## Prerequisites
@@ -76,5 +76,4 @@ $
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `GEMINI_API_KEY` | Yes | — | Your Gemini API key. Used by the local server to call the Gemini API. |
-| `SSHQ_GEMINI_MODEL` | No | `gemini-2.5-flash` | Gemini model name used for command suggestions. |
-| `SSHQ_TUNNEL_PORT` | No | `5000` | Local port for the reverse SSH tunnel and the host server. Change this if port 5000 is already in use. |
+| `SSHQ_GEMINI_MODEL` | No | `gemini-2.5-flash` | Gemini model used for command suggestions. You can also use `gemini-2.5-flash-lite`, which typically offers a higher quota. |

--- a/src/sshq/cli.py
+++ b/src/sshq/cli.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import socket
 import subprocess
 import threading
 import base64
@@ -75,7 +76,9 @@ def main():
         print("Usage: sshq [standard ssh arguments, e.g., user@host]")
         sys.exit(1)
 
-    port = int(os.environ.get("SSHQ_TUNNEL_PORT", "5000"))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
 
     # Build the q script with the configured port
     q_script = Q_SCRIPT.format(port=port)

--- a/src/sshq/server.py
+++ b/src/sshq/server.py
@@ -5,11 +5,11 @@ from flask import Flask, request, jsonify
 from google import genai
 from google.genai import types
 
-# 1. Suppress standard Werkzeug request logging
+# Suppress standard Werkzeug request logging
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 
-# 2. Modern way to suppress the Flask startup banner
+# Suppress the Flask startup banner
 flask.cli.show_server_banner = lambda *args: None
 
 app = Flask(__name__)
@@ -42,10 +42,9 @@ def ask():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-def start_server(port=None):
+def start_server(port):
     global client
     # Client automatically picks up the GEMINI_API_KEY environment variable
     client = genai.Client()
 
-    port = port or int(os.environ.get("SSHQ_TUNNEL_PORT", "5000"))
     app.run(port=port, host='127.0.0.1', debug=False)


### PR DESCRIPTION
- Pick an available port with a temporary socket bind and use it for the local server and SSH reverse tunnel
- Make start_server(port) require the port; remove SSHQ_TUNNEL_PORT env
- Update README: describe random port in "How it Works" and remove SSHQ_TUNNEL_PORT from the env vars table